### PR TITLE
Publish raw ruby image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.5
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,13 @@ jobs:
           name: Build the Ruby image
           command: docker build -f Dockerfile.ruby -t rubocophq/ruby-snapshot:latest .
       - run:
+          name: Push the Ruby image to Docker Hub
+          command: docker push rubocophq/ruby-snapshot:latest
+      - run:
           name: Build the CircleCI variant of the Ruby image
           command: docker build -f Dockerfile.circle -t rubocophq/circleci-ruby-snapshot:latest .
       - run:
-          name: Push the image to Docker Hub
+          name: Push the CircleCI image to Docker Hub
           command: docker push rubocophq/circleci-ruby-snapshot:latest
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/rubocop-hq/circleci-ruby-snapshot-image/tree/master.svg?style=svg)](https://circleci.com/gh/rubocop-hq/circleci-ruby-snapshot-image/tree/master)
 
-We needed to test the RuboCop projects on CircleCI against a “nightly” build of Ruby. But the official Ruby docker images (https://github.com/docker-library/ruby) do not include a nightly build, and so the CircleCI Docker images (https://github.com/circleci/circleci-images) also didn’t include one. So we build and publish such an image ourselves.
+We needed to test the RuboCop projects on CircleCI against a “nightly” build of Ruby. But the official Ruby docker images (https://github.com/docker-library/ruby) do not include a nightly build, and so the CircleCI Docker images (https://github.com/circleci/circleci-images) also didn’t include one. So we build and publish these images ourselves.
 
 Once per day, the “daily” workflow is run on CircleCI, building a new Docker image from the Ruby “Nightly Snapshot”, and from that image a CircleCI compatible Docker image is built.
 
-The images are published to https://hub.docker.com/r/rubocophq/circleci-ruby-snapshot/
+The images are published to https://hub.docker.com/r/rubocophq/ruby-snapshot/ and https://hub.docker.com/r/rubocophq/circleci-ruby-snapshot/


### PR DESCRIPTION
Let’s also publish the “not CircleCI specific” nightly Ruby image to Docker Hub. We build it anyway, so there’s not a lot of extra work involved in making it public: https://hub.docker.com/r/rubocophq/ruby-snapshot/

