### PR TITLE
Use shallow clone from git, not snapshot.tar.xz

### DIFF
--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -25,12 +25,12 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/snapshot.tar.xz" \
+	\
 	\
 	\
 	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
+	&& git clone --depth 1 https://github.com/ruby/ruby.git /usr/src/ruby \
+	\
 	\
 	&& cd /usr/src/ruby \
 	\

--- a/generate-ruby-dockerfile.sh
+++ b/generate-ruby-dockerfile.sh
@@ -4,6 +4,8 @@ curl https://raw.githubusercontent.com/docker-library/ruby/master/2.6/stretch/Do
   sed 's/^ENV RUBY_MAJOR 2\.6$//' |
   sed 's/^ENV RUBY_VERSION 2\.6\.0$//' |
   sed 's/^ENV RUBY_DOWNLOAD_SHA256 [0-9a-f]\{64\}$//' |
-  sed 's|https://cache\.ruby-lang\.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION\.tar\.xz|https://cache.ruby-lang.org/pub/ruby/snapshot.tar.xz|' |
-  sed 's/&& echo "$RUBY_DOWNLOAD_SHA256 \*ruby\.tar\.xz" | sha256sum -c - \\/\\/' \
+  sed 's|&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" ||' |
+  sed 's/&& echo "$RUBY_DOWNLOAD_SHA256 \*ruby.tar.xz" | sha256sum -c - //' |
+  sed 's|tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1|git clone --depth 1 https://github.com/ruby/ruby.git /usr/src/ruby|' |
+  sed 's/&& rm ruby.tar.xz //' \
   > Dockerfile.ruby


### PR DESCRIPTION
For some reason when building Ruby from the snapshot download, the executables in /usr/local/lib/ruby/gems/*/gems/*/exe have 0700 permissions, instead of 0755. Building from the git checkout seems to fix that.

Fixes #8.

I have not pushed an image with this fix so you can test the fix for yourselves, but [I ran a build](https://circleci.com/gh/rubocop-hq/circleci-ruby-snapshot-image/445) that near the end has these lines:
```
Step 8/9 : RUN ls -l /usr/local/lib/ruby/gems/*/gems/*/exe
 ---> Running in 37a43f6d8d61
/usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.0.1/exe:
total 8
-rwxr-xr-x 1 root root 949 Jan 13 20:35 bundle
-rwxr-xr-x 1 root root  96 Jan 13 20:35 bundler

/usr/local/lib/ruby/gems/2.7.0/gems/irb-1.0.0/exe:
total 4
-rwxr-xr-x 1 root root 182 Jan 13 20:35 irb

/usr/local/lib/ruby/gems/2.7.0/gems/rdoc-6.1.0/exe:
total 8
-rwxr-xr-x 1 root root 938 Jan 13 20:35 rdoc
-rwxr-xr-x 1 root root 188 Jan 13 20:35 ri
 ---> bc3f3b9e54fa
Removing intermediate container 37a43f6d8d61
```