### PR TITLE
Use BUNDLE_PATH__SYSTEM instead of BUNDLE_PATH=GEM_HOME

### DIFF
--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -61,7 +61,7 @@ RUN set -ex \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/generate-ruby-dockerfile.sh
+++ b/generate-ruby-dockerfile.sh
@@ -9,5 +9,6 @@ curl https://raw.githubusercontent.com/docker-library/ruby/master/2.6/stretch/Do
   sed 's/&& echo "$RUBY_DOWNLOAD_SHA256 \*ruby.tar.xz" | sha256sum -c - //' |
   sed 's|tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1|git clone --depth 1 https://github.com/ruby/ruby.git /usr/src/ruby|' |
   sed 's/&& rm ruby.tar.xz //' |
+  sed 's/BUNDLE_PATH="$GEM_HOME"/BUNDLE_PATH__SYSTEM=true/' |
 
   cat > Dockerfile.ruby


### PR DESCRIPTION
It will fix  rubocop-hq/rubocop#7124


See https://github.com/bundler/bundler/issues/7197 for the problem and solution.


It works on my local machine.

```bash
docker build -f Dockerfile.ruby -t rubocophq/ruby-snapshot:latest .
docker run --rm -it rubocophq/ruby-snapshot:latest bash

# in docker
git clone https://github.com/rubocop-hq/rubocop
cd rubocop
bundle install
ruby -I lib -r rubocop -e 'exit 0'
echo $? # => 0
```

And `bundle exec rake` also works.

Thanks, @deivid-rodriguez!