### PR TITLE
Build new images on master branch change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,15 @@ jobs:
 
 workflows:
   version: 2
-  check-dockerfiles:
+  on-branch-push:
     jobs:
       - check-ruby-dockerfile-generation
       - check-circle-dockerfile-generation
+      - build:
+          filters:
+            branches:
+              only:
+                - master
 
   # It looks like the snapshots are currently released to
   # https://cache.ruby-lang.org/pub/ruby/ around 12:30-12:40. E.g.


### PR DESCRIPTION
Most often, the master branch is only changed because the "daily" workflow has failed. So it makes sense when presumably the "daily" workflow is fixed, that we attempt to rebuild the images that are more than 24 hours old by this time.