### PR TITLE
Fix build by disabling docker_layer_caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
       - image: circleci/ruby
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Sign in to docker
           command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USER --password-stdin


### PR DESCRIPTION
Builds have been failing since 2019-10-17 with the message:

> execution not authorized due to: free-plan-docker-layer-caching-unavailable

- [Last successful build](https://circleci.com/gh/rubocop-hq/circleci-ruby-snapshot-image/1326)
- [First failed build](https://circleci.com/gh/rubocop-hq/circleci-ruby-snapshot-image/1327)

Apparently CircleCI changed their feature offering to OSS projects without notice. E.g. https://circleci.com/docs/2.0/docker-layer-caching/ says (as of 2019-10-29) “Docker Layer Caching is only available on the Performance usage plan.”