### PR TITLE
Use ruby:2.7 as template instead of ruby:2.6

### DIFF
--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:buster
 
 # skip installing gem documentation
 RUN set -eux; \

--- a/generate-ruby-dockerfile.sh
+++ b/generate-ruby-dockerfile.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-curl https://raw.githubusercontent.com/docker-library/ruby/master/2.6/stretch/Dockerfile |
+curl https://raw.githubusercontent.com/docker-library/ruby/master/2.7/buster/Dockerfile |
 
-  sed 's/^ENV RUBY_MAJOR 2\.6$//' |
-  sed 's/^ENV RUBY_VERSION 2\.6\.[0-9][0-9]*$//' |
+  sed 's/^ENV RUBY_MAJOR 2\.7$//' |
+  sed 's/^ENV RUBY_VERSION 2\.7\.[0-9][0-9]*$//' |
   sed 's/^ENV RUBY_DOWNLOAD_SHA256 [0-9a-f]\{64\}$//' |
   sed 's|wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; ||' |
   sed 's/echo "$RUBY_DOWNLOAD_SHA256 \*ruby.tar.xz" | sha256sum --check --strict; //' |


### PR DESCRIPTION
Build nightly Ruby based on how the official ruby:2.7 image is built. Now that Ruby 2.7 is officially released, I think we can assume that Dockerfile will be more regularly updated than the Ruby 2.6 one.

See also #7.